### PR TITLE
dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+    commit-message:
+      prefix: "🤖 "
+    groups:
+      actions:
+        patterns: ["*"]
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
for github actions (currently only dprint)